### PR TITLE
Fix sell payment method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "banxa-js-sdk",
-  "version": "1.0.0",
+  "name": "@banxa-global/js-sdk",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "banxa-js-sdk",
-      "version": "1.0.0",
+      "name": "@banxa-global/js-sdk",
+      "version": "1.0.2",
       "license": "ISC",
       "dependencies": {
         "axios": "^0.24.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@banxa-global/js-sdk",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,8 +72,8 @@ export default class Banxa {
 
     public getSellPaymentMethods(coinCode: string, fiatCode: string) {
         return new GetPaymentMethods(this.httpClient)
-            .setTarget(coinCode)
-            .setSource(fiatCode)
+            .setSource(coinCode)
+            .setTarget(fiatCode)
             .get()
     }
 

--- a/tests/unit/banxa.spec.ts
+++ b/tests/unit/banxa.spec.ts
@@ -108,7 +108,7 @@ describe('banxa test', function () {
             .get('/api/payment-methods?source=BTC&target=AUD')
             .reply(200, PaymentMethodsResponse.get())
         const resp = await Banxa.create('SUBDOMAIN', 'API', 'SECRET', true)
-            .getSellPaymentMethods('AUD', 'BTC');
+            .getSellPaymentMethods('BTC', 'AUD');
         assert.equal(Array.isArray(resp), true);
     });
 

--- a/tests/unit/banxa.spec.ts
+++ b/tests/unit/banxa.spec.ts
@@ -229,7 +229,7 @@ describe('banxa test', function () {
 
     it('can getOrder', async function () {
         nock('https://subdomain.banxa-sandbox.com', {"encodedQueryParams": true})
-            .get('/api/order/84cecea94e3b8c08386623e46503aebc')
+            .get('/api/orders/84cecea94e3b8c08386623e46503aebc')
             .reply(200, OrderResponse.getOrder())
         const resp = await Banxa.create('SUBDOMAIN', 'API', 'SECRET', true)
             .getOrder('84cecea94e3b8c08386623e46503aebc');


### PR DESCRIPTION
The get sell payment method in the SDK is not sending the fiat and coin type correctly. This PR has fixed the issue.