### PR TITLE
Fix get prices with alternate amount

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ combination. Should be called when a user requests prices by providing the crypt
 
 ### Buy order types pricing
 
-> **Fetch single available price for buy order type for a specific payment method**
+> **Fetch available price for buy order type for all payment method**
 >```js
 > banxa.getAllBuyPrices(
 >   fiatCode,
@@ -465,6 +465,23 @@ combination. Should be called when a user requests prices by providing the crypt
 | `fiatCode`   | `string`           | `true`   | Fiat code e.g. 'USD' or 'EUR' see [Fiat](#fiat) to get a list all available fiats                            |
 | `coinCode`   | `string`           | `true`   | Coin code e.g. 'BTC' or 'ETH' see [Crypto](#crypto) to get a list all available crypto                       |
 | `fiatAmount` | `string/number` | `true`   | Fiat amount                                                                                                  |
+| `blockchain` | `string`           | `false`  | Blockchain code e.g. 'ETH' or 'TRON' see [Crypto](#crypto) to get a list all available blockchains per coin. |
+
+> **Fetch available price for buy order type for all payment method with coin amount**
+>```js
+> banxa.getAllBuyPricesFromCoinAmount(
+>   fiatCode,
+>   coinCode,
+>   coinAmount,
+>   blockchain
+> )
+>```
+
+| Property      | description        | required | description                                                                                                  |
+|:--------------|:-------------------|:---------|:-------------------------------------------------------------------------------------------------------------|
+| `fiatCode`   | `string`           | `true`   | Fiat code e.g. 'USD' or 'EUR' see [Fiat](#fiat) to get a list all available fiats                            |
+| `coinCode`   | `string`           | `true`   | Coin code e.g. 'BTC' or 'ETH' see [Crypto](#crypto) to get a list all available crypto                       |
+| `coinAmount` | `string/number`    | `true`   | Coin amount                                                                                                  |
 | `blockchain` | `string`           | `false`  | Blockchain code e.g. 'ETH' or 'TRON' see [Crypto](#crypto) to get a list all available blockchains per coin. |
 
 **Result Example**
@@ -524,6 +541,25 @@ combination. Should be called when a user requests prices by providing the crypt
 | `payment_method_id` | `string/number` | `true`   | Unique ID for the payment method that you want to get prices for. see [Payment Methods](#payment-methods) to get a list of payment providers. |
 | `blockchain`        | `string`           | `false`  | Blockchain code e.g. 'ETH' or 'TRON' see [Crypto](#crypto) to get a list all available blockchains per coin.                                  |
 
+> **Fetch single price for buy order type for a specific payment method with coin amount**
+> ```js
+> banxa.getBuyPricesFromCoinAmount(
+>    fiatCode,
+>    coinCode,
+>    coinAmount,
+>    paymentMethodId,
+>    blockchain
+> )
+>```
+
+| Property             | type               | required | required                                                                                                                                      |
+|:---------------------|:-------------------|:---------|:----------------------------------------------------------------------------------------------------------------------------------------------|
+| `fiatCode`          | `string`           | `true`   | Fiat code e.g. 'USD' or 'EUR see [Fiat](#fiat) to get a list all available fiats                                                              |
+| `coinCode`          | `string`           | `true`   | Coin code e.g. 'BTC' or 'ETH see [Crypto](#crypto) to get a list all available crypto                                                         |
+| `coinAmount`        | `string/number` | `true`   | Coin amount                                                                                                                                   |
+| `payment_method_id` | `string/number` | `true`   | Unique ID for the payment method that you want to get prices for. see [Payment Methods](#payment-methods) to get a list of payment providers. |
+| `blockchain`        | `string`           | `false`  | Blockchain code e.g. 'ETH' or 'TRON' see [Crypto](#crypto) to get a list all available blockchains per coin.    
+
 **Result Example**
 
 ```json
@@ -557,6 +593,21 @@ combination. Should be called when a user requests prices by providing the crypt
 | `coinCode`   | `string`           | `true`   | Coin code e.g. 'BTC' or 'ETH' see [Crypto](#crypto) to get a list all available crypto |
 | `fiatCode`   | `string`           | `true`   | Fiat code e.g. 'USD' or 'EUR' see [Fiat](#fiat) to get a list all available fiats      |
 | `coinAmount` | `string/number` | `true`   | Crypto amount that will be used to calculate the fiat amount                           |
+
+> **Fetch all available prices for sell order type with fiat amount**
+> ```js
+> banxa.getAllSellPricesFromFiatAmount(
+>   coinCode, 
+>   fiatCode, 
+>   fiatAmount
+> )
+> ```
+
+| Property      | type               | required | description                                                                            |
+|:--------------|:-------------------|:---------|:---------------------------------------------------------------------------------------|
+| `coinCode`   | `string`           | `true`   | Coin code e.g. 'BTC' or 'ETH' see [Crypto](#crypto) to get a list all available crypto |
+| `fiatCode`   | `string`           | `true`   | Fiat code e.g. 'USD' or 'EUR' see [Fiat](#fiat) to get a list all available fiats      |
+| `fiatAmount` | `string/number` | `true`   | Fiat amount that will be used to calculate the coin amount                           |
 
 **Result Example**
 
@@ -609,6 +660,23 @@ combination. Should be called when a user requests prices by providing the crypt
 | `coinCode`          | `string`        | `true`   | Coin code e.g. 'BTC' or 'ETH' see [Crypto](#crypto) to get a list all available crypto                                                        |
 | `fiatCode`          | `string`        | `true`   | Fiat code e.g. 'USD' or 'EUR' see [Fiat](#fiat) to get a list all available fiats                                                             |
 | `coinAmount`        | `string/number` | `true`   | Crypto amount that will be used to calculate                                                                                                  |
+| `payment_method_id` | `string/number` | `true`   | Unique ID for the payment method that you want to get prices for. see [Payment Methods](#payment-methods) to get a list of payment providers. |
+
+> **Fetch single price for buy order type for a specific payment method with fiat amount**
+> ```js
+> banxa.getSellPricesFromFiatAmount(
+>   coinCode, 
+>   fiatCode, 
+>   fiatAmount, 
+>   paymentMethodId
+> )
+>```
+
+| Property             | type            | required | description                                                                                                                                   |
+|:---------------------|:----------------|:---------|:----------------------------------------------------------------------------------------------------------------------------------------------|
+| `coinCode`          | `string`        | `true`   | Coin code e.g. 'BTC' or 'ETH' see [Crypto](#crypto) to get a list all available crypto                                                        |
+| `fiatCode`          | `string`        | `true`   | Fiat code e.g. 'USD' or 'EUR' see [Fiat](#fiat) to get a list all available fiats                                                             |
+| `fiatAmount`        | `string/number` | `true`   | Fiat amount that will be used to calculate                                                                                                  |
 | `payment_method_id` | `string/number` | `true`   | Unique ID for the payment method that you want to get prices for. see [Payment Methods](#payment-methods) to get a list of payment providers. |
 
 **Result Example**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@banxa-global/js-sdk",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@banxa-global/js-sdk",
-  "version": "1.0.4",
+  "version": "1.0.3",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/domains/prices/getPrices.ts
+++ b/src/domains/prices/getPrices.ts
@@ -6,6 +6,7 @@ export class GetPrices extends Domain {
     private _source: string = '';
     private _target: string = '';
     private _source_amount?: string | number;
+    private _target_amount?: string | number;
     private _payment_method_id? : string | number;
     private _blockchain?: string;
     private path = 'api/prices';
@@ -26,6 +27,7 @@ export class GetPrices extends Domain {
             [keyConstants._SOURCE] : this.source,
             [keyConstants._TARGET] : this.target,
             [keyConstants._SOURCE_AMOUNT] : this.sourceAmount,
+            [keyConstants._TARGET_AMOUNT] : this.targetAmount,
             [keyConstants._PAYMENT_METHOD_ID] : this.paymentMethodId,
             [keyConstants._BLOCKCHAIN] : this.blockchain,
         }
@@ -65,6 +67,15 @@ export class GetPrices extends Domain {
 
     public setSourceAmount(source_amount: string | number) {
         this._source_amount = source_amount?.toString();
+        return this;
+    }
+
+    private get targetAmount(): string | undefined {
+        return this._target_amount?.toString();
+    }
+
+    public setTargetAmount(target_amount: string | number) {
+        this._target_amount = target_amount?.toString();
         return this;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,11 +87,31 @@ export default class Banxa {
             .get()
     }
 
+    public getAllBuyPricesFromCoinAmount(fiatCode: string, coinCode: string, coinAmount: string | number, blockchain?: string) {
+        return new GetPrices(this.httpClient)
+            .setSource(fiatCode)
+            .setTarget(coinCode)
+            .setTargetAmount(coinAmount)
+            .setPaymentMethodId()
+            .setBlockchain(blockchain)
+            .get()
+    }
+
     public getBuyPrices(fiatCode: string, coinCode: string, fiatAmount: string | number, paymentMethodId: string | number, blockchain?: string) {
         return new GetPrices(this.httpClient)
             .setSource(fiatCode)
             .setTarget(coinCode)
             .setSourceAmount(fiatAmount)
+            .setPaymentMethodId(paymentMethodId)
+            .setBlockchain(blockchain)
+            .get()
+    }
+
+    public getBuyPricesFromCoinAmount(fiatCode: string, coinCode: string, coinAmount: string | number, paymentMethodId: string | number, blockchain?: string) {
+        return new GetPrices(this.httpClient)
+            .setSource(fiatCode)
+            .setTarget(coinCode)
+            .setTargetAmount(coinAmount)
             .setPaymentMethodId(paymentMethodId)
             .setBlockchain(blockchain)
             .get()
@@ -107,11 +127,31 @@ export default class Banxa {
             .get()
     }
 
+    public getAllSellPricesFromFiatAmount(coinCode: string, fiatCode: string, fiatAmount: string | number) {
+        return new GetPrices(this.httpClient)
+            .setSource(coinCode)
+            .setTarget(fiatCode)
+            .setTargetAmount(fiatAmount)
+            .setPaymentMethodId()
+            .setBlockchain()
+            .get()
+    }
+
     public getSellPrices(coinCode: string, fiatCode: string, coinAmount: string | number, paymentMethodId: string) {
         return new GetPrices(this.httpClient)
             .setSource(coinCode)
             .setTarget(fiatCode)
             .setSourceAmount(coinAmount)
+            .setPaymentMethodId(paymentMethodId)
+            .setBlockchain()
+            .get()
+    }
+
+    public getSellPricesFromFiatAmount(coinCode: string, fiatCode: string, fiatAmount: string | number, paymentMethodId: string) {
+        return new GetPrices(this.httpClient)
+            .setSource(coinCode)
+            .setTarget(fiatCode)
+            .setTargetAmount(fiatAmount)
             .setPaymentMethodId(paymentMethodId)
             .setBlockchain()
             .get()

--- a/tests/unit/banxa.spec.ts
+++ b/tests/unit/banxa.spec.ts
@@ -121,12 +121,30 @@ describe('banxa test', function () {
         assert.equal(Array.isArray(resp), true);
     });
 
+    it('can getAllBuyPrices from coin amount', async function () {
+        nock('https://subdomain.banxa-sandbox.com', {"encodedQueryParams": true})
+            .get('/api/prices?source=AUD&target=BTC&target_amount=1.0123&blockchain=BTC')
+            .reply(200, PricesResponse.get())
+        const resp = await Banxa.create('SUBDOMAIN', 'API', 'SECRET', true)
+            .getAllBuyPricesFromCoinAmount('AUD', 'BTC', '1.0123', 'BTC');
+        assert.equal(Array.isArray(resp), true);
+    });
+
     it('can getBuyPrices', async function () {
         nock('https://subdomain.banxa-sandbox.com', {"encodedQueryParams": true})
             .get('/api/prices?source=AUD&target=BTC&source_amount=100.25&payment_method_id=101&blockchain=BTC')
             .reply(200, PricesResponse.get())
         const resp = await Banxa.create('SUBDOMAIN', 'API', 'SECRET', true)
             .getBuyPrices('AUD', 'BTC', '100.25', 101, 'BTC');
+        assert.equal(Array.isArray(resp), true);
+    });
+
+    it('can getBuyPrices from coin amount', async function () {
+        nock('https://subdomain.banxa-sandbox.com', {"encodedQueryParams": true})
+            .get('/api/prices?source=AUD&target=BTC&target_amount=1.0123&payment_method_id=101&blockchain=BTC')
+            .reply(200, PricesResponse.get())
+        const resp = await Banxa.create('SUBDOMAIN', 'API', 'SECRET', true)
+            .getBuyPricesFromCoinAmount('AUD', 'BTC', '1.0123', 101, 'BTC');
         assert.equal(Array.isArray(resp), true);
     });
 
@@ -139,12 +157,30 @@ describe('banxa test', function () {
         assert.equal(Array.isArray(resp), true);
     });
 
+    it('can getAllSellPrices from fiat amount', async function () {
+        nock('https://subdomain.banxa-sandbox.com', {"encodedQueryParams": true})
+            .get('/api/prices?source=BTC&target=AUD&target_amount=300.5')
+            .reply(200, PricesResponse.get())
+        const resp = await Banxa.create('SUBDOMAIN', 'API', 'SECRET', true)
+            .getAllSellPricesFromFiatAmount('BTC', 'AUD', '300.5');
+        assert.equal(Array.isArray(resp), true);
+    });
+
     it('can getSellPrices', async function () {
         nock('https://subdomain.banxa-sandbox.com', {"encodedQueryParams": true})
             .get('/api/prices?source=BTC&target=AUD&source_amount=100.25&payment_method_id=2102')
             .reply(200, PricesResponse.get())
         const resp = await Banxa.create('SUBDOMAIN', 'API', 'SECRET', true)
             .getSellPrices('BTC', 'AUD', '100.25', '2102');
+        assert.equal(Array.isArray(resp), true);
+    });
+
+    it('can getSellPrices from fiat amount', async function () {
+        nock('https://subdomain.banxa-sandbox.com', {"encodedQueryParams": true})
+            .get('/api/prices?source=BTC&target=AUD&target_amount=300.5&payment_method_id=2102')
+            .reply(200, PricesResponse.get())
+        const resp = await Banxa.create('SUBDOMAIN', 'API', 'SECRET', true)
+            .getSellPricesFromFiatAmount('BTC', 'AUD', '300.5', '2102');
         assert.equal(Array.isArray(resp), true);
     });
 
@@ -229,7 +265,7 @@ describe('banxa test', function () {
 
     it('can getOrder', async function () {
         nock('https://subdomain.banxa-sandbox.com', {"encodedQueryParams": true})
-            .get('/api/order/84cecea94e3b8c08386623e46503aebc')
+            .get('/api/orders/84cecea94e3b8c08386623e46503aebc')
             .reply(200, OrderResponse.getOrder())
         const resp = await Banxa.create('SUBDOMAIN', 'API', 'SECRET', true)
             .getOrder('84cecea94e3b8c08386623e46503aebc');


### PR DESCRIPTION
In contrast to our APIs, the Node SDK is unable to get price with an alternate amount (i.e. unable to quote with coin amount for buy order and fiat amount for sell order). This fix has added 4 new function to the SDK to support it.